### PR TITLE
Issue #4. Code of Conduct and update readme to point to it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # RetroSockets
+
 ###_You've got feels. We've got websockets_
 
 ### OVERVIEW
 This is a rebuild of my former retrosockets app with React. I was previously using only jQuery and Socket.io. It worked fine, but was hard to maintain / improve because nothing was well organized. React solved a lot of those problems for me.
 
 ### PURPOSE
-Retrosockets is a proof of concept retrospective tool for remote or dispersed teams. 
+Retrosockets is a proof of concept retrospective tool for remote or dispersed teams.
 
 ### DEMO
 https://retrosockets.herokuapp.com/
@@ -19,3 +20,6 @@ https://retrosockets.herokuapp.com/
 **This app also works on your phone and other devices. To use with multiple devices locally:**
 * find your local IP (_On a Mac it's under System Preferences/Network just under the status line._)
 
+## Code Of Conduct
+
+Please click [here](https://github.com/alanbsmith/react-retro-sockets/blob/master/code_of_conduct.md) to read the Code of Conduct for this project. It was copied from [Coraline Ada Ehmke's](http://where.coraline.codes/) excellent [Contributor Covenant](http://contributor-covenant.org/version/1/4/code_of_conduct.md) and we feel it represents the tenets of a positive and inviting community.

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,79 @@
+# Contributor Covenant Code of Conduct
+
+## Other Translations
+
+Click [here](http://contributor-covenant.org/i18n/) for other translations of
+this code of conduct.
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/


### PR DESCRIPTION
I wasn't sure how to do the link to the `CoC` any other way than being explicit and referencing blob/master. If you know a better way, please edit before merging.